### PR TITLE
Update MTLiveMailService.swift

### DIFF
--- a/Sources/MailTMSwift/Services/MTLiveMailService.swift
+++ b/Sources/MailTMSwift/Services/MTLiveMailService.swift
@@ -59,8 +59,8 @@ open class MTLiveMailService {
     private let accountId: String
     
     /// Retry the listener automatically when the connection goes off
-    /// - Note: Default is false
-    let autoRetry = false
+    /// - Note: Default is true
+    var autoRetry = false
     
     /// Create a new instance
     /// - Parameters:


### PR DESCRIPTION
Fix a bug where `autoRetry` property of `MTLiveMailService` is constant